### PR TITLE
WIP Returning all Repos for a User

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -1,0 +1,5 @@
+class ReposController < ApplicationController
+  def index
+    @repo_search = RepoSearchResult.new(ENV['token'])
+  end
+end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -1,0 +1,8 @@
+class Repo
+  attr_reader :name, :url
+
+  def initialize(attributes)
+    @name = attributes[:name]
+    @url = attributes[:url]
+  end
+end

--- a/app/models/repo_search_result.rb
+++ b/app/models/repo_search_result.rb
@@ -1,0 +1,17 @@
+class RepoSearchResult
+  def initialize(user_token)
+    @user_token = user_token
+  end
+
+  def repos
+    conn = Faraday.new(:url => 'https://api.github.com') do |faraday|
+      faraday.headers['access_token'] = ENV['token']
+      faraday.adapter Faraday.default_adapter
+    end
+    response = conn.get('/users/hmesander/repos')
+    data = JSON.parse(response.body, symbolize_names: true)
+    data.map do |raw_repo|
+      Repo.new(raw_repo)
+    end
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,1 +1,1 @@
-
+<%= link_to "Repositories", repos_path %>

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -1,0 +1,6 @@
+<ul>
+  <h2><%= @repo_search.repos.count %> Repositories</h2>
+</ul>
+<% @repo_search.repos.each do |repo| %>
+  <li><%= link_to repo.name, repo.url %></li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   get '/auth/github/callback', to: 'sessions#create'
   get '/dashboard', to: 'dashboard#index'
   get '/logout', to: 'sessions#destroy'
+  get '/repos', to: 'repos#index'
 end

--- a/spec/features/user_can_see_repos_spec.rb
+++ b/spec/features/user_can_see_repos_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+def stub_omniauth
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new({
+    provider: 'github',
+    info: {
+      nickname: 'hmesander',
+      name: 'Haley Mesander',
+      screen_name: 'hmesander'
+    },
+    credentials: {
+      token: ENV['token']
+    },
+    extra: {
+      raw_info: {
+        id: '37840583',
+        avatar_url: 'https://avatars0.githubusercontent.com/u/33385692?v=4'
+      }
+    }
+  })
+end
+
+feature "User clicks on 'Respositories'" do
+  scenario 'they see a list of their repos ' do
+    stub_omniauth
+
+    visit root_path
+
+    click_on 'Log in with Github'
+
+    expect(current_path).to eq(dashboard_path)
+
+    click_on 'Repositories'
+
+    expect(current_path).to eq(repos_path)
+    expect(page).to have_content('44 Repositories')
+    expect(page).to have_css('.repo', count: 44)
+  end
+end


### PR DESCRIPTION
-Can return index of user repos, with links to raw data on each repo (manually tested only)

Still working on:
- Dynamically returning a repo based on the current logged-in user
- Automated testing